### PR TITLE
Pass context into browse() so translations work when generating labels

### DIFF
--- a/label/report/dynamic_label.py
+++ b/label/report/dynamic_label.py
@@ -39,7 +39,7 @@ class report_dynamic_label(report_sxw.rml_parse):
         label_print_data = label_print_obj.browse(self.cr, self.uid, self.context.get('label_print'))
         result = []
         value_vals = []
-        for datas in active_model_obj.browse(self.cr, self.uid, ids):
+        for datas in active_model_obj.browse(self.cr, self.uid, ids, context=self.context):
             for i in range(0, number_of_copy):
                 vals=[]
                 bot = False


### PR DESCRIPTION
If someone edits a translatable field (such as product name) on an existing record while working under a translated language, the change gets stored as a translation in ir.translation instead of in the model's postgres table.

By passing in the context to the browse() method, these updated values will make it through to the labels when they're generated with the same language, rather than mysteriously disappearing.
