### PR TITLE
[ADD] Feature fields of equality

### DIFF
--- a/base_synchro/models/base_synchro_obj.py
+++ b/base_synchro/models/base_synchro_obj.py
@@ -47,6 +47,8 @@ class base_synchro_obj(models.Model):
     server_id = fields.Many2one('base.synchro.server', 'Server', ondelete='cascade', select=1, required=True)
     model_id =  fields.Many2one('ir.model', string='Object to synchronize', required=True)
     action = fields.Selection([('d', 'Download'), ('u', 'Upload'), ('b', 'Both')], 'Synchronisation direction', required=True, default='d')
+    fields_of_equality =  fields.Many2many('ir.model.fields', 'model_field_synchro_obj_rel',
+            'field_id', 'synchro_obj_id', string='Fields of Equality', help="Fields used to check if there is a record equals in destiny.")
     sequence =  fields.Integer('Sequence')
     active =  fields.Boolean('Active', default=True)
     synchronize_date = fields.Datetime('Latest Synchronization', readonly=True)

--- a/base_synchro/views/base_synchro_view.xml
+++ b/base_synchro/views/base_synchro_view.xml
@@ -87,6 +87,7 @@
                             <field name="action"/>
                             <field name="sequence"/>
                             <field colspan="4" name="domain"/>
+                            <field name="fields_of_equality" widget="many2many_tags" domain="[('model_id', '=', model_id)]"/>
                             <field name="synchronize_date"/>
                         </group>
                         <separator string="Fields Not Sync."/>


### PR DESCRIPTION
It helps to not duplicate dest records that already exists before
synchronization. It checks equality in dest using the fields set at
fields_of_equality.
For example, to check account.journal, we can use code and name to check
if it exists in dest. So it will not be duplicated and avoid constraint
error.