### PR TITLE
partner_credit_limit: fix incorrect account.move.line search

### DIFF
--- a/partner_credit_limit/__manifest__.py
+++ b/partner_credit_limit/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     'name': 'Partner Credit Limit',
-    'version': '10.0.1.2.0',
+    'version': '10.0.2.0.0',
     'category': 'Partner',
     'depends': ['account', 'sale'],
     'license': 'AGPL-3',

--- a/partner_credit_limit/__manifest__.py
+++ b/partner_credit_limit/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     'name': 'Partner Credit Limit',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.1.0',
     'category': 'Partner',
     'depends': ['account', 'sale'],
     'license': 'AGPL-3',

--- a/partner_credit_limit/__manifest__.py
+++ b/partner_credit_limit/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     'name': 'Partner Credit Limit',
-    'version': '10.0.1.1.0',
+    'version': '10.0.1.2.0',
     'category': 'Partner',
     'depends': ['account', 'sale'],
     'license': 'AGPL-3',

--- a/partner_credit_limit/models/sale.py
+++ b/partner_credit_limit/models/sale.py
@@ -17,8 +17,8 @@ class SaleOrder(models.Model):
         moveline_obj = self.env['account.move.line']
         movelines = moveline_obj.\
             search([('partner_id', '=', partner.id),
-                    ('account_id.user_type_id.name', 'in',
-                    ['Receivable', 'Payable']),
+                    ('account_id.user_type_id.type', 'in',
+                    ['receivable', 'payable']),
                     ('full_reconcile_id', '=', False)])
 
         debit, credit = 0.0, 0.0

--- a/partner_credit_limit/models/sale.py
+++ b/partner_credit_limit/models/sale.py
@@ -11,8 +11,10 @@ from odoo.exceptions import UserError
 class SaleOrder(models.Model):
     _inherit = "sale.order"
 
-    @api.one
+    @api.multi
     def check_limit(self):
+        """Check if credit limit for partner was exceeded."""
+        self.ensure_one()
         partner = self.partner_id
         moveline_obj = self.env['account.move.line']
         movelines = moveline_obj.\

--- a/partner_credit_limit/models/sale.py
+++ b/partner_credit_limit/models/sale.py
@@ -45,7 +45,7 @@ class SaleOrder(models.Model):
 
     @api.multi
     def action_confirm(self):
-        res = super(SaleOrder, self).action_confirm()
+        """Extend to check credit limit before confirming sale order."""
         for order in self:
             order.check_limit()
-        return res
+        return super(SaleOrder, self).action_confirm()


### PR DESCRIPTION
We can't simply use `name` of model `account.account.type` to search related move lines. Because firstly `name` is not fixed (users change name to anything they want), second `name` field is so if language is changed to other then English, and there is translation, it will return incorrect results, because search will find any related moves anymore.