### PR TITLE
[FIX] synchronize_date not being set

### DIFF
--- a/base_synchro/wizard/base_synchro.py
+++ b/base_synchro/wizard/base_synchro.py
@@ -246,7 +246,7 @@ class BaseSynchro(models.TransientModel):
             if obj_rec.action == 'b':
                 time.sleep(1)
                 dt = time.strftime('%Y-%m-%d %H:%M:%S')
-            self.env['base.synchro.obj'].write({'synchronize_date': dt})
+            obj_rec.write({'synchronize_date': dt})
         end_date = time.strftime('%Y-%m-%d, %Hh %Mm %Ss')
 #        return {}
         if syn_obj.user_id:


### PR DESCRIPTION
On the 9.0 branch, the synchronize_date of the synced models was not being set, causing everything to be synced every time the tool was run.

I saw the issue had been fixed on 10.0 by doing something similar (commit 9e87e7b), so this is basically a back-port.