### PR TITLE
[ADD] Migrated project_kanban module in v11.

### DIFF
--- a/project_kanban/__manifest__.py
+++ b/project_kanban/__manifest__.py
@@ -4,20 +4,23 @@
 
 {
     'name': 'Project - Status by Recent Activities',
-    'version': '10.0.1.0.0',
+    'version': '11.0.1.0.0',
     'author': 'Serpent Consulting Services Pvt. Ltd.',
+    'license': 'AGPL-3',
     'maintainer': 'Serpent Consulting Services Pvt. Ltd.',
     'website': 'http://www.serpentcs.com',
     'summary': """Find your Idle projects - Displays last
                 updated date and recent updated date
                 for the Project.""",
-    'depends': ['project'],
+    'depends': [
+        'project',
+    ],
     'category': 'Project Management',
-    'license': 'AGPL-3',
-    'sequence': 1,
-    'data': ['views/project_kanban_view.xml'],
-    'images': ['static/description/ProjectKanban.png'],
-    'sequence': 1,
+    'data': [
+        'views/project_kanban_view.xml',
+    ],
+    'images': [
+        'static/description/ProjectKanban.png',
+    ],
     'installable': True,
-    'auto_install': False,
 }

--- a/project_kanban/models/project.py
+++ b/project_kanban/models/project.py
@@ -8,12 +8,13 @@ from odoo import api, fields, models
 class Project(models.Model):
     _inherit = 'project.project'
 
-    @api.multi
     @api.depends('message_ids')
     def _compute_get_recent_date(self):
-        for rec in self:
-            date_lst = [x.date for x in rec.message_ids]
-            rec.recent_date = date_lst and max(date_lst) or False
+        for project in self:
+            # TODO: It can be improved using tasks of the projects
+            # instead of message_ids
+            date_lst = [x.date for x in project.message_ids]
+            project.recent_date = date_lst and max(date_lst) or False
 
     recent_date = fields.Datetime(compute="_compute_get_recent_date",
                                   string="Recent date")

--- a/project_kanban/tests/test_project_kanban.py
+++ b/project_kanban/tests/test_project_kanban.py
@@ -5,13 +5,13 @@
 from odoo.tests import common
 
 
-class ProjectTestCase(common.TransactionCase):
+class ProjectKanbanTest(common.TransactionCase):
     def setup(self):
-        super(ProjectTestCase, self).setup()
+        super(ProjectKanbanTest, self).setup()
 
     def test_project_kanban(self):
         self.project_obj = self.env['project.project']
-        self.record = self.project_obj.\
-            create({'name': 'Project Kanban',
-                    'recent_date': self.project_obj._compute_get_recent_date()
-                    })
+        self.project_obj.create({
+            'name': 'Project Kanban',
+            'recent_date': self.project_obj._compute_get_recent_date(),
+        })

--- a/project_kanban/views/project_kanban_view.xml
+++ b/project_kanban/views/project_kanban_view.xml
@@ -1,24 +1,21 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
 
-    <!--INHERITED PROJECT FORM-->
-    <record id="project_kanaban_view_form" model="ir.ui.view">
-        <field name="name">project.kanban.view.form</field>
+    <record id="view_project_kanaban_form" model="ir.ui.view">
+        <field name="name">project.kanban.form</field>
         <field name="model">project.project</field>
         <field name="inherit_id" ref="project.edit_project"/>
         <field name="arch" type="xml">
             <field name="partner_id" position="after">
-                <newline/>
                 <field name="write_date" readonly="1"/>
-                <newline/>
                 <field name="recent_date"/>
+                <field name="__last_update"/>
             </field>
         </field>
     </record>
 
-    <!--INHERITED PROJECT KANBAN-->
-    <record id="project_kanaban_view_kanban" model="ir.ui.view">
-        <field name="name">project.kanban.view.kanban</field>
+    <record id="view_project_kanaban_kanban" model="ir.ui.view">
+        <field name="name">project.kanban.kanban</field>
         <field name="model">project.project</field>
         <field name="inherit_id" ref="project.view_project_kanban"/>
         <field name="arch" type="xml">
@@ -26,22 +23,21 @@
                 <field name="write_date"/>
                 <field name="recent_date"/>
             </field>
-            <xpath expr="//div[contains(@class, 'o_kanban_primary_left')]"
-                   position="after">
+            <div class="o_kanban_primary_left"
+                 position="after">
                 <a style="font-size: 10px;">
                     Last updated on:
                     <field name="write_date"/>
                 </a>
-            </xpath>
-            <xpath expr="//div[contains(@class, 'o_kanban_primary_left')]"
-                   position="after">
                 <div style="font-size: 10px;">
                     <a>
                         Recent Log Date:
                         <field name="recent_date" string="Recent Date"/>
+                        <field name="__last_update"/>
                     </a>
                 </div>
-            </xpath>
+            </div>
         </field>
     </record>
+
 </odoo>


### PR DESCRIPTION
Migrated project_kanban module in v11.

Module name project_kanban doesn't make any sense according to the feature.
I guess it can be ideal_project_kanban or something else that is related with the feature.

@JayVora-SerpentCS Please review.