### PR TITLE
[10.0][FIX] Fix label key error in label when model_list isn't defined in context

### DIFF
--- a/label/models/label_print.py
+++ b/label/models/label_print.py
@@ -105,8 +105,9 @@ class IrModelFields(models.Model):
 
     @api.model
     def name_search(self, name='', args=None, operator='ilike', limit=None):
-        data = self._context['model_list']
-        args.append(('model', 'in', eval(data)))
+        if 'model_list' in self._context.keys():
+            data = self._context['model_list']
+            args.append(('model', 'in', eval(data)))
         ret_vat = super(IrModelFields, self).name_search(name=name,
                                                          args=args,
                                                          operator=operator,


### PR DESCRIPTION
Please pull, I've just spotted this small error triggered when the self._context doesn't contain model_list 