### PR TITLE
[IMP][partner_credit_limit]Set over_credit on True

### DIFF
--- a/partner_credit_limit/models/partner.py
+++ b/partner_credit_limit/models/partner.py
@@ -8,4 +8,4 @@ from odoo import fields, models
 class ResPartner(models.Model):
     _inherit = 'res.partner'
 
-    over_credit = fields.Boolean('Allow Over Credit?')
+    over_credit = fields.Boolean('Allow Over Credit?', default=True)


### PR DESCRIPTION
If we leave the false field, once installed blocks all the customers present in the db, creating problems if there were dozens of customers.