### PR TITLE
[9.0] website_multi_image_zoom use small images and links instead of embedding

### DIFF
--- a/website_multi_image_zoom/models/product_images.py
+++ b/website_multi_image_zoom/models/product_images.py
@@ -20,7 +20,7 @@
 #
 ##############################################################################
 
-from openerp import fields, models
+from openerp import api, fields, models, tools
 
 
 class ProductImage(models.Model):
@@ -31,12 +31,19 @@ class ProductImage(models.Model):
     description = fields.Text(string='Description')
     image_alt = fields.Text(string='Image Label')
     image = fields.Binary(string='Image')
-    image_small = fields.Binary(string='Small Image')
+    image_small = fields.Binary(
+        string='Small Image', compute='_compute_image_small', store=True,
+    )
     image_url = fields.Char(string='Image URL')
     product_tmpl_id = fields.Many2one('product.template', 'Product',
                                       copy=False)
     product_variant_id = fields.Many2one('product.product', 'Product Variant',
                                          copy=False)
+
+    @api.depends('image')
+    def _compute_image_small(self):
+        for this in self:
+            this.image_small = tools.image_resize_image_small(this.image)
 
 
 class ProductProduct(models.Model):

--- a/website_multi_image_zoom/static/src/js/zoom.js
+++ b/website_multi_image_zoom/static/src/js/zoom.js
@@ -17,11 +17,18 @@ $(window).load(function() {
     }else{
         $('#ex1').children().children().removeAttr( "id" ); // remove all attributes
     }
+    $('#thumb_img_add img[data-image-full]').each(function() {
+        $(document.head).append($('<link/>').attr({
+            rel: 'preload',
+            href: $(this).data('image-full'),
+            as: 'image',
+        }));
+    });
 });
 
 //Method to change Main product image when click on thumbnail image
 function pro_img_click(proimg) {
-	$('#ex1').children().children().attr("src", proimg.src);
+	$('#ex1').children().children().attr("src", $(proimg).data('image-full') || proimg.src);
 	var wi = $(window).width();
 	if (wi >= 980) {
 		$('#ex1').children().children().attr("id", "image2"); // Give Id to image

--- a/website_multi_image_zoom/static/src/js/zoom.js
+++ b/website_multi_image_zoom/static/src/js/zoom.js
@@ -28,7 +28,9 @@ $(window).load(function() {
 
 //Method to change Main product image when click on thumbnail image
 function pro_img_click(proimg) {
-	$('#ex1').children().children().attr("src", $(proimg).data('image-full') || proimg.src);
+	$('#ex1').children().children()
+        .attr("src", $(proimg).data('image-full') || proimg.src)
+        .attr("style", null);
 	var wi = $(window).width();
 	if (wi >= 980) {
 		$('#ex1').children().children().attr("id", "image2"); // Give Id to image

--- a/website_multi_image_zoom/views/templates.xml
+++ b/website_multi_image_zoom/views/templates.xml
@@ -62,11 +62,11 @@
                             <!-- Indicators -->
                             <ol class='carousel-indicators'>
                                 <li>
-                                    <img onclick="pro_img_click(this)" itemprop="image" class="image_thumb img-responsive" t-att-src="'data:image/jpeg;base64,%s' %product.image" />
+                                    <img onclick="pro_img_click(this)" itemprop="image" class="image_thumb img-responsive" t-att-src="request.website.image_url(product, 'image_small')" t-att-data-image-full="request.website.image_url(product, 'image')" />
                                 </li>
                                 <t t-foreach="product.images" t-as="i">
                                     <li>
-                                        <img onclick="pro_img_click(this)" class="image_thumb img-responsive" t-att-src="'data:image/jpeg;base64,%s' %i.image" />
+                                        <img onclick="pro_img_click(this)" class="image_thumb img-responsive" t-att-src="request.website.image_url(i, 'image_small')" t-att-data-image-full="request.website.image_url(i, 'image')" />
                                     </li>
                                 </t>
                             </ol>


### PR DESCRIPTION
we use this plugin with rather large images, and without this patch, a product detail page can easily be several MB