### PR TITLE
[10.0][IMP][label] Remove python expression size in label field

### DIFF
--- a/label/models/label_print.py
+++ b/label/models/label_print.py
@@ -93,7 +93,7 @@ class LabelPrintField(models.Model):
                              ('image', 'Image')],
                             'Type', required=True, default='normal')
     python_expression = fields.Boolean('Python Expression')
-    python_field = fields.Char('Fields', size=32)
+    python_field = fields.Char('Fields')
     fontsize = fields.Float("Font Size", default=8.0)
     position = fields.Selection([('left', 'Left'), ('right', 'Right'),
                                  ('top', 'Top'), ('bottom', 'Bottom')],


### PR DESCRIPTION
This PR remove the 32 char limitation when using field with python expression because prevent to do more "complex" things.