### PR TITLE
[FIX] base_synchro: Fix decorator and Adept view_type according to v13

### DIFF
--- a/base_synchro/__manifest__.py
+++ b/base_synchro/__manifest__.py
@@ -2,7 +2,7 @@
 
 {
     "name": "Multi-DB Synchronization",
-    "version": "12.0.1.0.0",
+    "version": "12.0.2.0.0",
     "category": "Tools",
     "license": "AGPL-3",
     "summary": "Multi-DB Synchronization",

--- a/base_synchro/views/base_synchro_view.xml
+++ b/base_synchro/views/base_synchro_view.xml
@@ -53,7 +53,7 @@
         <field name="name">Filters</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">base.synchro.obj.line</field>
-        <field name="view_type">form</field>
+        <field name="binding_view_types">form</field>
         <field name="view_id" ref="view_transfer_line_tree"/>
         <field name="search_view_id" ref="ir_filters_transfer_line_form"/>
     </record>
@@ -62,7 +62,7 @@
         <field name="name">Synchronized instances</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">base.synchro.obj.line</field>
-        <field name="view_type">form</field>
+        <field name="binding_view_types">form</field>
     </record>
 
     <menuitem id="next_id_63" name="History"
@@ -142,7 +142,7 @@
         <field name="name">Synchronized objects</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">base.synchro.obj</field>
-        <field name="view_type">form</field>
+        <field name="binding_view_types">form</field>
     </record>
 
     <menuitem action="action_transfer_tree" id="transfer_menu_id"
@@ -184,7 +184,7 @@
         <field name="name">Servers to be synchronized</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">base.synchro.server</field>
-        <field name="view_type">form</field>
+        <field name="binding_view_types">form</field>
     </record>
 
     <menuitem action="action_base_synchro_server_tree" id="synchro_server_tree_menu_id"

--- a/base_synchro/views/res_request_view.xml
+++ b/base_synchro/views/res_request_view.xml
@@ -55,7 +55,7 @@
         <field name="name">Request Report</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">res.request</field>
-        <field name="view_type">form</field>
+        <field name="binding_view_types">form</field>
         <field name="view_mode">tree,form</field>
         <field name="search_view_id" ref="view_res_request_search"/>
     </record>

--- a/base_synchro/wizard/base_synchro.py
+++ b/base_synchro/wizard/base_synchro.py
@@ -243,7 +243,6 @@ class BaseSynchro(models.TransientModel):
         del data['id']
         return data
 
-    @api.multi
     def upload_download(self):
         self.ensure_one()
         self.report = []
@@ -286,14 +285,13 @@ Exceptions:
             })
             return {}
 
-    @api.multi
     def upload_download_multi_thread(self):
         threaded_synchronization = \
             threading.Thread(target=self.upload_download())
         threaded_synchronization.run()
         id2 = self.env.ref('base_synchro.view_base_synchro_finish').id
         return {
-            'view_type': 'form',
+            'binding_view_types': 'form',
             'view_mode': 'form',
             'res_model': 'base.synchro',
             'views': [(id2, 'form')],

--- a/base_synchro/wizard/base_synchro_view.xml
+++ b/base_synchro/wizard/base_synchro_view.xml
@@ -26,7 +26,7 @@
         <field name="name">Base Synchronization</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">base.synchro</field>
-        <field name="view_type">form</field>
+        <field name="binding_view_types">form</field>
         <field name="view_mode">form</field>
         <field name="view_id" ref="view_base_synchro"/>
         <field name="target">new</field>


### PR DESCRIPTION
Fixes #426 

Before this commit, there was traceback on Installing `base_synchro` module as `multi` decorator and `view_type` has been removed from Odoo 13.

In this commit, We remove deprecated decorator and adept `view_type` according to Odoo 13.