### PR TITLE
[FIX] base_module_record: Fix decorator and Adept view_type according to v13

### DIFF
--- a/base_module_record/__manifest__.py
+++ b/base_module_record/__manifest__.py
@@ -2,7 +2,7 @@
 
 {
     'name': 'Record and Create Modules',
-    'version': '12.0.1.0.0',
+    'version': '13.0.1.0.0',
     'category': 'Tools',
     'license': 'AGPL-3',
     'author': 'Serpent Consulting Services Pvt. Ltd.',

--- a/base_module_record/wizard/base_module_record_data.py
+++ b/base_module_record/wizard/base_module_record_data.py
@@ -33,7 +33,6 @@ class BaseModuleData(models.TransientModel):
         res_xml = self.env['ir.module.record'].generate_xml()
         return {'res_text': res_xml}
 
-    @api.multi
     def record_objects(self):
         data = self.read([])[0]
         check_date = data['check_date']
@@ -70,7 +69,7 @@ class BaseModuleData(models.TransientModel):
             return {
                 'name': _('Data Recording'),
                 'context': {'default_res_text': ustr(res['res_text'])},
-                'view_type': 'form',
+                'binding_view_types': 'form',
                 'view_mode': 'form',
                 'res_model': 'base.module.record.data',
                 'views': [(res_id, 'form')],
@@ -82,7 +81,7 @@ class BaseModuleData(models.TransientModel):
         return {
             'name': _('Module Recording'),
             'context': {},
-            'view_type': 'form',
+            'binding_view_types': 'form',
             'view_mode': 'form',
             'res_model': 'base.module.record.objects',
             'views': [(res_id, 'form')],

--- a/base_module_record/wizard/base_module_record_data_view.xml
+++ b/base_module_record/wizard/base_module_record_data_view.xml
@@ -27,7 +27,7 @@
     <record id="action_base_module_record_data" model="ir.actions.act_window">
         <field name="name">Export Customizations as Data</field>
         <field name="res_model">base.module.data</field>
-        <field name="view_type">form</field>
+        <field name="binding_view_types">form</field>
         <field name="view_mode">form</field>
         <field name="target">new</field>
         <field name="view_id" ref="base_module_record_data_view"/>
@@ -41,11 +41,8 @@
     <act_window id="act_base_module_record_data"
                 name="Export Customizations As Data File"
                 res_model="base.module.data"
-                src_model="ir.module.module"
-                view_mode="form"
-                target="new"
-                multi="True"
-                key2="client_action_multi"/>
+                binding_model="ir.module.module"
+                binding_views="list"/>
 
     <record id="module_create_xml_view" model="ir.ui.view">
         <field name="name">module.create.xml.form</field>

--- a/base_module_record/wizard/base_module_record_object_view.xml
+++ b/base_module_record/wizard/base_module_record_object_view.xml
@@ -25,7 +25,7 @@
     <record id="action_base_module_record_objects" model="ir.actions.act_window">
         <field name="name">Export Customizations as a Module</field>
         <field name="res_model">base.module.record</field>
-        <field name="view_type">form</field>
+        <field name="binding_view_types">form</field>
         <field name="view_mode">form</field>
         <field name="target">new</field>
         <field name="view_id" ref="base_module_record_objects_view"/>
@@ -43,11 +43,8 @@
     <act_window id="act_base_module_record_objects"
                 name="Export Customizations As a Module"
                 res_model="base.module.record"
-                src_model="ir.module.module"
-                view_mode="form"
-                target="new"
-                multi="True"
-                key2="client_action_multi"/>
+                binding_model="ir.module.module"
+                binding_views="list"/>
 
     <record id="module_create_form_view" model="ir.ui.view">
         <field name="name">module.create.form</field>
@@ -79,7 +76,7 @@
     <record id="action_module_created" model="ir.actions.act_window">
         <field name="name">Module Recording</field>
         <field name="res_model">base.module.record.objects</field>
-        <field name="view_type">form</field>
+        <field name="binding_view_types">form</field>
         <field name="view_mode">form</field>
         <field name="target">new</field>
         <field name="view_id" ref="module_create_form_view"/>

--- a/base_module_record/wizard/base_module_record_objects.py
+++ b/base_module_record/wizard/base_module_record_objects.py
@@ -32,7 +32,6 @@ class BaseModuleRecord(models.TransientModel):
                                     ], string='Records only', required=True,
                                    default='created')
 
-    @api.multi
     def record_objects(self):
         data = self.read([])[0]
         check_date = data['check_date']
@@ -67,7 +66,7 @@ class BaseModuleRecord(models.TransientModel):
             return {
                 'name': _('Module Recording'),
                 'context': self._context,
-                'view_type': 'form',
+                'binding_view_types': 'form',
                 'view_mode': 'form',
                 'res_model': 'base.module.record.objects',
                 'views': [(res_id, 'form')],
@@ -79,7 +78,7 @@ class BaseModuleRecord(models.TransientModel):
         return {
             'name': _('Module Recording'),
             'context': self._context,
-            'view_type': 'form',
+            'binding_view_types': 'form',
             'view_mode': 'form',
             'res_model': 'base.module.record.objects',
             'views': [(res_id, 'form')],
@@ -111,7 +110,7 @@ class BaseModuleRecordObjects(models.TransientModel):
         }).id
         return {
             'name': _('Module Recording'),
-            'view_type': 'form',
+            'binding_view_types': 'form',
             'view_mode': 'form',
             'res_id': rec_id,
             'res_model': 'base.module.record.objects',


### PR DESCRIPTION
_This commit fixes Installation Issue on v13 (Module functionality yet to be checked)_


---------------------------

Before this commit, there was traceback on Installing base_module_record module as multi decorator and view_type has been removed from Odoo 13.

In this commit, We remove deprecated decorator and adept view_type according to Odoo 13.