### PR TITLE
Fix Resolving Virtual IDs

### DIFF
--- a/web_one2many_kanban/models/web_one2many_kanban.py
+++ b/web_one2many_kanban/models/web_one2many_kanban.py
@@ -8,11 +8,24 @@ class WebFieldData(http.Controller):
     @http.route(["/web/fetch_x2m_data"], type="json", auth="public")
     def get_o2x_data(self, **kwargs):
         o2x_records = kwargs.get("o2x_records")
+        o2x_record_datas = kwargs.get("o2x_record_data")
         o2x_datas = []
-        for record in o2x_records:
+        for idx, record in enumerate(o2x_records):
             o2x_model = record.get("relation", False)
             o2x_ids = record.get("raw_value", False)
             if o2x_model:
                 o2x_obj = request.env[o2x_model]
-                o2x_datas.append(o2x_obj.search_read([("id", "in", o2x_ids)]))
+                all_real = all([isinstance(x, int) for x in o2x_ids])
+                all_virt = not any([isinstance(x, int) for x in o2x_ids])
+                if all_real:
+                    o2x_datas.append(o2x_obj.search_read([("id", "in", o2x_ids)]))
+                elif all_virt:
+                    o2x_datas.append([x["data"] for x in o2x_record_datas[idx]["data"]])
+                else:
+                    o2x_datas.append([])
+                    for item in o2x_record_datas[idx]["data"]:
+                        if isinstance(item["data"].get("id"), int):
+                            o2x_datas[-1].append(o2x_obj.search_read([("id", "=", item["data"]["id"])]))
+                        else:
+                            o2x_datas[-1].append(item["data"])
         return o2x_datas

--- a/web_one2many_kanban/static/src/js/web_one2many_kanban.js
+++ b/web_one2many_kanban/static/src/js/web_one2many_kanban.js
@@ -19,16 +19,18 @@ odoo.define('web_one2many_kanban.web_one2many_kanban', function (require) {
 
             if ( o2x_field_names.length > 0) {
                 var o2x_records = [];
+                var o2x_recordData = [];
                 _.each(o2x_field_names, function (o2x_field_name) {
                     var record = self.qweb_context.record[o2x_field_name];
                     if (record.type === 'one2many') {
                         o2x_records.push(record);
+                        o2x_recordData.push(self.recordData[o2x_field_name])
                     }
                 });
                 def = ajax.jsonRpc(
                     "/web/fetch_x2m_data",
                     "call",
-                    {'o2x_records': o2x_records}).then(function (o2x_datas) {
+                    {'o2x_records': o2x_records, 'o2x_record_data': o2x_recordData}).then(function (o2x_datas) {
                     for (var i=0; i<o2x_datas.length; i++) {
                         o2x_records[i].raw_value = o2x_datas[i];
                     }


### PR DESCRIPTION
Hi,

I'm note sure if this is really right, but when you are using a one2many kanban and allow adding records, the resulting ids sent to server are virtual and fail with a not an integer error. In this case we take the data already stored clientside in cache.

To be honest this could be more efficient, because if all the ids are virtual, there is no need to perform an RPC call at all to get_o2x_data at all, but my javascript is not very good.